### PR TITLE
Get Business Orders Endpoint

### DIFF
--- a/app/controllers/api/v1/businesses/account_controller.rb
+++ b/app/controllers/api/v1/businesses/account_controller.rb
@@ -7,9 +7,7 @@ class Api::V1::Businesses::AccountController < ApplicationController
   end
 
   private
-
   def account_params
     params.permit(:api_key)
   end
-
 end

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -1,0 +1,12 @@
+class Api::V1::OrdersController < ApplicationController
+  def index
+    business = get_business(api_key_params[:api_key])
+    orders = Order.find_by(business_id: business.id)
+    render json: OrderSerializer.new(orders), status: 200
+  end
+
+  private
+  def api_key_params
+    params.permit(:api_key)
+  end
+end

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -1,7 +1,6 @@
 class Api::V1::OrdersController < ApplicationController
   def index
-    business = get_business(request_body[:api_key])
-    orders = Order.where(business_id: business.id)
+    orders = Order.where(business: get_business(request_body[:api_key]))
     render json: OrderSerializer.new(orders), status: 200
   end
 

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::OrdersController < ApplicationController
   def index
     business = get_business(api_key_params[:api_key])
-    orders = Order.find_by(business_id: business.id)
+    orders = Order.where(business_id: business.id)
     render json: OrderSerializer.new(orders), status: 200
   end
 

--- a/app/serializers/order_serializer.rb
+++ b/app/serializers/order_serializer.rb
@@ -1,0 +1,6 @@
+class OrderSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes  :id,
+              :total_cost,
+              :total_revenue
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get '/items', to: 'items#index'
+      get '/orders', to: 'orders#index'
       get '/business_items', to: 'business_items#index'
       post '/business_items', to: 'business_items#create'
       namespace :businesses do

--- a/spec/requests/api/v1/orders_request_spec.rb
+++ b/spec/requests/api/v1/orders_request_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe 'Orders API', :type => :request do
+  context 'with a correct API key' do
+    it 'sends a list of orders for a successful request' do
+      distributor = Distributor.create!(name: 'RNDC',
+                                          address: '3319 Arapahoe st, Denver, CO',
+                                          code: 'CODE12345',
+                                          api_key: 'jgn983hy48thw9begh98h4539h41',
+                                          password: 'password'
+                                          )
+
+      rep = create(:representative, distributor: distributor)
+      business = create(:business, api_key: '111111111', distributor: distributor, representative: rep)
+
+      create(:business, api_key: '999999', distributor: distributor, representative: rep)
+
+      order = create(:order, business: business)
+
+      get '/api/v1/orders', params: {'api_key': business.api_key}
+
+      result = JSON.parse(response.body)['data']
+
+      expect(response.status).to eq(200)
+      expect(result['id']).to eq(order.id.to_s)
+      expect(result['type']).to eq('order')
+      expect(result['attributes']['id']).to eq(order.id)
+      expect(result['attributes']['total_cost']).to eq(order.total_cost)
+      expect(result['attributes']['total_revenue']).to eq(order.total_revenue)
+    end
+  end
+
+  context 'with an incorrect API key' do
+    it 'responds with a 404 not found status' do
+
+      get '/api/v1/orders', :params => {'api_key': 'incorrect_key'}
+
+      expect(response.status).to eq(404)
+      expect(JSON.parse(response.body)['error']).to eq("Couldn't find Business")
+    end
+  end
+end

--- a/spec/requests/api/v1/orders_request_spec.rb
+++ b/spec/requests/api/v1/orders_request_spec.rb
@@ -14,54 +14,39 @@ describe 'Orders API', :type => :request do
     @rep = create(:representative, distributor: @distributor)
     @business = create(:business, distributor: @distributor, representative: @rep)
     @business_2 = create(:business, distributor: @distributor, representative: @rep)
-    @order = create(:order, business: @business)
+    @order_1 = create(:order, business: @business)
+    @order_2 = create(:order, business: @business)
   end
+
   context 'with a correct API key' do
     it 'sends a list of orders for a successful request' do
-      distributor = Distributor.create!(name: 'RNDC',
-                                        address: '3319 Arapahoe st, Denver, CO',
-                                        code: 'CODE12345',
-                                        api_key: 'jgn983hy48thw9begh98h4539h41',
-                                        password: 'password'
-                                        )
-
-
-      
-      create(:order, business: @business_2)
 
       get '/api/v1/orders', params: {'api_key': @business.api_key}
 
       result = JSON.parse(response.body)['data']
-
       expect(response.status).to eq(200)
-      expect(result.count).to eq(1)
-      expect(result[0]['id']).to eq(order_1.id.to_s)
+      expect(result.count).to eq(2)
+      expect(result[0]['id']).to eq(@order_1.id.to_s)
       expect(result[0]['type']).to eq('order')
-      expect(result[0]['attributes']['id']).to eq(order_1.id)
-      expect(result[0]['attributes']['total_cost']).to eq(order_1.total_cost)
-      expect(result[0]['attributes']['total_revenue']).to eq(order_1.total_revenue)
+      expect(result[0]['attributes']['id']).to eq(@order_1.id)
+      expect(result[0]['attributes']['total_cost']).to eq(@order_1.total_cost)
+      expect(result[0]['attributes']['total_revenue']).to eq(@order_1.total_revenue)
     end
 
-    it 'sends a message for successful request, but there are no orders in the databse' do
-      distributor = Distributor.create!(name: 'RNDC',
-                                        address: '3319 Arapahoe st, Denver, CO',
-                                        code: 'CODE12345',
-                                        api_key: 'jgn983hy48thw9begh98h4539h41',
-                                        password: 'password'
-                                        )
+    it 'sends a message for successful request, but there are no orders in the database' do
 
-      get '/api/v1/orders', params: {'api_key': @business.api_key}
+      get '/api/v1/orders', params: {'api_key': @business_2.api_key}
 
       result = JSON.parse(response.body)
 
       expect(response.status).to eq(200)
       expect(result['data']).to eq([])
     end
-  context 'with a correct API key' do
+
     it 'creates an order for a successful request' do
 
       body = {
-              "api_key": @business.api_key,
+              "api_key": @business_2.api_key,
               "total_cost": "200",
               "total_revenue": "4",
               "items": [
@@ -78,28 +63,28 @@ describe 'Orders API', :type => :request do
               ]
             }
 
-      expect(Order.all.count).to eq(0)
+      expect(@business_2.orders.count).to eq(0)
 
       post '/api/v1/orders', params: body
       result = JSON.parse(response.body)['data']
 
       expect(response.status).to eq(201)
       expect(result).to eq(nil)
-      expect(Order.all.count).to eq(1)
-      expect(Order.all[0].total_cost).to eq(body[:total_cost].to_f)
-      expect(Order.all[0].total_revenue).to eq(body[:total_revenue].to_f)
-      expect(Order.all[0].items[0].id).to eq(@item_1.id)
-      expect(Order.all[0].items[1].id).to eq(@item_2.id)
-      expect(Order.all[0].business_id).to eq(@business.id)
+      expect(@business_2.orders.count).to eq(1)
+      expect(@business_2.orders[0].total_cost).to eq(body[:total_cost].to_f)
+      expect(@business_2.orders[0].total_revenue).to eq(body[:total_revenue].to_f)
+      expect(@business_2.orders[0].items[0].id).to eq(@item_1.id)
+      expect(@business_2.orders[0].items[1].id).to eq(@item_2.id)
+      expect(@business_2.orders[0].business_id).to eq(@business_2.id)
       expect(OrderItem.all.count).to eq(2)
-      expect(OrderItem.all[0].order_id).to eq(Order.all[0].id)
-      expect(OrderItem.all[1].order_id).to eq(Order.all[0].id)
-      expect(OrderItem.all[0].item_id).to eq(@item_1.id)
-      expect(OrderItem.all[1].item_id).to eq(@item_2.id)
-      expect(OrderItem.all[0].quantity).to eq(4)
-      expect(OrderItem.all[1].quantity).to eq(2)
-      expect(OrderItem.all[0].price).to eq(5.8)
-      expect(OrderItem.all[1].price).to eq(20.0)
+      expect(@business_2.order_items[0].order_id).to eq(@business_2.orders[0].id)
+      expect(@business_2.order_items[1].order_id).to eq(@business_2.orders[0].id)
+      expect(@business_2.order_items[0].item_id).to eq(@item_1.id)
+      expect(@business_2.order_items[1].item_id).to eq(@item_2.id)
+      expect(@business_2.order_items[0].quantity).to eq(4)
+      expect(@business_2.order_items[1].quantity).to eq(2)
+      expect(@business_2.order_items[0].price).to eq(5.8)
+      expect(@business_2.order_items[1].price).to eq(20.0)
     end
 
     it 'responds with a 422 status for bad request due to missing total_cost and total_revenue' do
@@ -145,7 +130,7 @@ describe 'Orders API', :type => :request do
       expect(JSON.parse(response.body)['price']).to eq(["can't be blank", "is not a number"])
       expect(JSON.parse(response.body)['quantity']).to eq(["can't be blank", "is not a number"])
     end
-    
+
     it 'responds with a 404 status' do
       params = {'api_key': 'incorrect_key',
                 'total_cost': '200',
@@ -165,6 +150,7 @@ describe 'Orders API', :type => :request do
 
       post '/api/v1/orders', :params => params
     end
+  end
 
   context 'with an incorrect API key' do
     it 'responds with a 404 not found status' do

--- a/spec/requests/api/v1/orders_request_spec.rb
+++ b/spec/requests/api/v1/orders_request_spec.rb
@@ -11,22 +11,43 @@ describe 'Orders API', :type => :request do
                                           )
 
       rep = create(:representative, distributor: distributor)
-      business = create(:business, api_key: '111111111', distributor: distributor, representative: rep)
+      business_1 = create(:business, api_key: '111111111', distributor: distributor, representative: rep)
 
-      create(:business, api_key: '999999', distributor: distributor, representative: rep)
+      business_2 = create(:business, api_key: '999999', distributor: distributor, representative: rep)
 
-      order = create(:order, business: business)
+      order_1 = create(:order, business: business_1)
+      create(:order, business: business_2)
 
-      get '/api/v1/orders', params: {'api_key': business.api_key}
+      get '/api/v1/orders', params: {'api_key': business_1.api_key}
 
       result = JSON.parse(response.body)['data']
 
       expect(response.status).to eq(200)
-      expect(result['id']).to eq(order.id.to_s)
-      expect(result['type']).to eq('order')
-      expect(result['attributes']['id']).to eq(order.id)
-      expect(result['attributes']['total_cost']).to eq(order.total_cost)
-      expect(result['attributes']['total_revenue']).to eq(order.total_revenue)
+      expect(result.count).to eq(1)
+      expect(result[0]['id']).to eq(order_1.id.to_s)
+      expect(result[0]['type']).to eq('order')
+      expect(result[0]['attributes']['id']).to eq(order_1.id)
+      expect(result[0]['attributes']['total_cost']).to eq(order_1.total_cost)
+      expect(result[0]['attributes']['total_revenue']).to eq(order_1.total_revenue)
+    end
+
+    it 'sends a message for successful request, but there are no orders in the databse' do
+      distributor = Distributor.create!(name: 'RNDC',
+                                          address: '3319 Arapahoe st, Denver, CO',
+                                          code: 'CODE12345',
+                                          api_key: 'jgn983hy48thw9begh98h4539h41',
+                                          password: 'password'
+                                          )
+
+      rep = create(:representative, distributor: distributor)
+      business = create(:business, api_key: '111111111', distributor: distributor, representative: rep)
+
+      get '/api/v1/orders', params: {'api_key': business.api_key}
+
+      result = JSON.parse(response.body)
+
+      expect(response.status).to eq(200)
+      expect(result['data']).to eq([])
     end
   end
 


### PR DESCRIPTION
### This Pull Request Implements:
- 200 status and list of orders for a successful GET request by a business
- 404 status for an invalid API key
- tested, along with sad path testing.
	
- [X] Linked To User Story on Trello

### This Pull Request Does Not:
Implement seeds for orders.

### Applicable Images
Correct API key, but no orders in the database:
![image](https://user-images.githubusercontent.com/42525195/58139422-c7c18d80-7bf7-11e9-927d-d482b3071edd.png)

Incorrect API key:
![image](https://user-images.githubusercontent.com/42525195/58139301-5e417f00-7bf7-11e9-98bc-e3809c86ee6f.png)
