### PR TITLE
05 28 19 add date to post and get orders 1

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -10,7 +10,6 @@ class Api::V1::OrdersController < ApplicationController
                           business: business)
     order.create_order_items(request_body[:items], order.id)
     fire_senders(order, business)
-    # render json: {created_at: order.created_at}, status: 201
     render json: OrderCreatedSerializer.new(order), status: 201
   end
 

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -10,7 +10,8 @@ class Api::V1::OrdersController < ApplicationController
                           business: business)
     order.create_order_items(request_body[:items], order.id)
     fire_senders(order, business)
-    render json: {}, status: 201
+    # render json: {created_at: order.created_at}, status: 201
+    render json: OrderCreatedSerializer.new(order), status: 201
   end
 
   private

--- a/app/models/order_info.rb
+++ b/app/models/order_info.rb
@@ -1,12 +1,14 @@
 class OrderInfo
   attr_reader :id,
               :total_cost,
-              :items
+              :items,
+              :created_at
 
   def initialize(order)
     @id = order.id
     @total_cost = order.total_cost
     @items = get_items(order.order_items)
+    @created_at = order.created_at
   end
 
 

--- a/app/serializers/order_created_serializer.rb
+++ b/app/serializers/order_created_serializer.rb
@@ -1,0 +1,5 @@
+class OrderCreatedSerializer
+    include FastJsonapi::ObjectSerializer
+    attributes  :id,
+                :created_at
+end

--- a/app/serializers/order_serializer.rb
+++ b/app/serializers/order_serializer.rb
@@ -1,6 +1,7 @@
 class OrderSerializer
   include FastJsonapi::ObjectSerializer
   attributes  :id,
+              :created_at,
               :total_cost,
               :items
 end

--- a/spec/requests/api/v1/orders_request_spec.rb
+++ b/spec/requests/api/v1/orders_request_spec.rb
@@ -31,6 +31,7 @@ describe 'Orders API', :type => :request do
       expect(result[0]['id']).to eq(@order_2.id.to_s)
       expect(result[0]['type']).to eq('order')
       expect(result[0]['attributes']['items']).to be_a(Array)
+      expect(result[0]['attributes']['created_at']).to be_a(String)
       expect(result[0]['attributes']['items'].length).to eq(@order_2.items.count)
       expect(result[0]['attributes']['id']).to eq(@order_2.id)
       expect(result[0]['attributes']['total_cost']).to eq(@order_2.total_cost)
@@ -83,7 +84,9 @@ describe 'Orders API', :type => :request do
       result = JSON.parse(response.body)['data']
 
       expect(response.status).to eq(201)
-      expect(result).to eq(nil)
+      expect(result['attributes']['created_at']).to be_a(String)
+      expect(result['attributes']['id']).to be_a(Integer)
+      expect(result['type']).to eq('order_created')
       expect(@business_2.orders.count).to eq(1)
       expect(@business_2.orders[0].total_cost).to eq(body[:total_cost].to_f)
       expect(@business_2.orders[0].items[0].id).to eq(@item_1.id)


### PR DESCRIPTION
### This Pull Request Implements:
- Adds created_at for POST & GET response for ORDERS.
- Tested

### Applicable Images
POST:
![image](https://user-images.githubusercontent.com/42525195/58519197-bc2e1380-816f-11e9-90e9-08b187adf2d5.png)

GET:
![image](https://user-images.githubusercontent.com/42525195/58519207-c94b0280-816f-11e9-85ca-f7556ba9631d.png)
